### PR TITLE
Add tt-blaze repo to STS subject pattern

### DIFF
--- a/chainguard/tt-blaze-craq-sim-read.sts.yaml
+++ b/chainguard/tt-blaze-craq-sim-read.sts.yaml
@@ -1,0 +1,16 @@
+# Identity name (also the filename, minus .sts.yaml): tt-blaze-craq-sim-read
+# Purpose: allow workflows in tenstorrent/tt-blaze to read tenstorrent/craq-sim.
+
+issuer: https://token.actions.githubusercontent.com
+
+# Only workflows running in tt-blaze, on any ref, can claim this identity.
+# Tighten to a specific branch (e.g. refs/heads/main) before production use.
+subject_pattern: "^repo:tenstorrent/(tt-blaze|internal-requests):.*$"
+
+# The permissions the issued token will carry.
+permissions:
+  contents: read
+
+# Apply those permissions to this repository only.
+repositories:
+  - craq-sim


### PR DESCRIPTION
This PR updates the Octo STS configuration file to include both `tt-blaze` and `internal-requests` repositories in the subject pattern.

## Changes
- Updated `subject_pattern` to allow workflows from both `tenstorrent/tt-blaze` and `tenstorrent/internal-requests` to claim this identity
- This aligns with the stated purpose of the file: allowing workflows in tt-blaze to read craq-sim

## Testing
This is currently configured for testing. The subject pattern will allow both repos to access the craq-sim read permissions.